### PR TITLE
Support input types

### DIFF
--- a/README.md
+++ b/README.md
@@ -115,7 +115,11 @@ inherit inputs and cascade down.
 
 The key `input_name` is a string and its value is a map of the input's
 configuration. The name can be used as an argument in the form `-<input_name>`
-or `--<input_name>` followed by a value. The input's value is a string.
+or `--<input_name>` followed by a value. The value can be omitted for boolean types.
+
+### `inputs.<input_name>.type`
+
+The type of input. Defaults to `string` but can also be `boolean`.
 
 ### `inputs.<input_name>.description`
 

--- a/README.md
+++ b/README.md
@@ -119,7 +119,7 @@ or `--<input_name>` followed by a value. The value can be omitted for boolean ty
 
 ### `inputs.<input_name>.type`
 
-The type of input. Defaults to `string` but can also be `boolean`.
+The type of input. Defaults to `string` but can also be `boolean` and `number`.
 
 ### `inputs.<input_name>.description`
 
@@ -167,6 +167,7 @@ inputs:
 ### `inputs.<input_name>.pattern`
 
 A regex pattern to validate the input's value. Default is to allow any input.
+Applies to `string` types only.
 
 #### Example setting an input pattern
 
@@ -181,6 +182,14 @@ inputs:
 Set the default value for the input. It is overwritten when a value is given as
 an argument or changed when prompted. If a default value is not defined then a
 value is required.
+
+### `inputs.<input_name>.min`
+
+The minimum value the input can be. Applies to `number` types only.
+
+### `inputs.<input_name>.max`
+
+The maximum value the input can be. Applies to `number` types only.
 
 ### `commands`
 

--- a/command_set.go
+++ b/command_set.go
@@ -146,15 +146,17 @@ func (cs CommandSet) ParseArgs(values *map[string]any) error {
 		// Don't do anything here. We just want the error.
 	}
 	for _, input := range cs.Inputs() {
+		// Set all default values
+		if input.DefaultValue != nil {
+			(*values)[input.Name] = input.DefaultValue
+		}
 		switch input.Type {
+		case "number":
+			fs.Float64(input.Name, 0.0, input.Description)
 		case "boolean":
-			b, ok := input.DefaultValue.(bool)
-			if !ok {
-				b = false
-			}
-			fs.Bool(input.Name, b, input.Description)
+			fs.Bool(input.Name, false, input.Description)
 		default:
-			fs.String(input.Name, input.DefaultValue.(string), input.Description)
+			fs.String(input.Name, "", input.Description)
 		}
 	}
 	if err := fs.Parse(cs.Args); err != nil {

--- a/command_set.go
+++ b/command_set.go
@@ -146,7 +146,7 @@ func (cs CommandSet) ParseArgs(values *map[string]any) error {
 		// Don't do anything here. We just want the error.
 	}
 	for _, input := range cs.Inputs() {
-		fs.String(input.Name, input.DefaultValue, input.Description)
+		fs.String(input.Name, fmt.Sprint(input.DefaultValue), input.Description)
 	}
 	if err := fs.Parse(cs.Args); err != nil {
 		return err

--- a/command_set.go
+++ b/command_set.go
@@ -222,9 +222,12 @@ func (cs CommandSet) ParseEnv(values *map[string]any, environ []string) {
 		name := strings.TrimPrefix(entry[0], EnvVarPrefix)
 		if input, ok := inputsMap[name]; !ok {
 			continue
+		} else if value, ok := input.Parse(entry[1]); !ok {
+			logger.Printf("Invalid value for input in environment: %s\n", input.Name)
+			continue
 		} else {
 			logger.Printf("Found value for input in environment: %s\n", input.Name)
-			(*values)[input.Name] = entry[1]
+			(*values)[input.Name] = value
 		}
 	}
 }

--- a/command_set.go
+++ b/command_set.go
@@ -146,7 +146,16 @@ func (cs CommandSet) ParseArgs(values *map[string]any) error {
 		// Don't do anything here. We just want the error.
 	}
 	for _, input := range cs.Inputs() {
-		fs.String(input.Name, fmt.Sprint(input.DefaultValue), input.Description)
+		switch input.Type {
+		case "boolean":
+			b, ok := input.DefaultValue.(bool)
+			if !ok {
+				b = false
+			}
+			fs.Bool(input.Name, b, input.Description)
+		default:
+			fs.String(input.Name, input.DefaultValue.(string), input.Description)
+		}
 	}
 	if err := fs.Parse(cs.Args); err != nil {
 		return err

--- a/command_set_test.go
+++ b/command_set_test.go
@@ -493,7 +493,31 @@ func TestCommandSetParseArgs(t *testing.T) {
 		}
 		expected := map[string]any{
 			"A": "aa",
+			"B": "b",
 			"C": "cc",
+		}
+		actual := make(map[string]any)
+		err := cs.ParseArgs(&actual)
+		assert.NoError(t, err, "CommandSet.ParseArgs() returned unexpected error")
+		assert.Equal(t, expected, actual, "CommandSet.ParseArgs() returned unexpected results")
+	})
+	t.Run("number", func(t *testing.T) {
+		cs := CommandSet{
+			Commands: []ConfigCommand{
+				{
+					Inputs: ConfigInputs{
+						ConfigInput{Name: "A", Type: "number"},
+						ConfigInput{Name: "B", Type: "number", DefaultValue: float64(456)},
+						ConfigInput{Name: "C", Type: "number", DefaultValue: float64(456)},
+					},
+				},
+			},
+			Args: []string{"--A", "123", "-B", "123"},
+		}
+		expected := map[string]any{
+			"A": float64(123),
+			"B": float64(123),
+			"C": float64(456),
 		}
 		actual := make(map[string]any)
 		err := cs.ParseArgs(&actual)
@@ -515,6 +539,7 @@ func TestCommandSetParseArgs(t *testing.T) {
 		}
 		expected := map[string]any{
 			"A": true,
+			"B": false,
 			"C": false,
 		}
 		actual := make(map[string]any)

--- a/command_set_test.go
+++ b/command_set_test.go
@@ -550,20 +550,21 @@ func TestCommandSetParseEnv(t *testing.T) {
 		Commands: []ConfigCommand{
 			{
 				Inputs: ConfigInputs{
-					ConfigInput{Name: "A", DefaultValue: ""},
-					ConfigInput{Name: "B", DefaultValue: "b"},
+					ConfigInput{Name: "A", Type: "string", DefaultValue: ""},
+					ConfigInput{Name: "B", Type: "string", DefaultValue: "b"},
 				},
 			},
 			{
 				Inputs: ConfigInputs{
-					ConfigInput{Name: "C", DefaultValue: "c"},
+					ConfigInput{Name: "C", Type: "string", DefaultValue: "c"},
+					ConfigInput{Name: "D", Type: "number"},
 				},
 			},
 		},
 		Args: []string{"-help"},
 	}
-	env := []string{"ILC_INPUT_A=a=a", "ILC_INPUT_C=", "ILC_INPUT_D=dd"}
-	expected := map[string]any{"A": "a=a", "C": ""}
+	env := []string{"ILC_INPUT_A=a=a", "ILC_INPUT_C=", "ILC_INPUT_D=123", "ILC_INPUT_E=ee"}
+	expected := map[string]any{"A": "a=a", "C": "", "D": int64(123)}
 	actual := make(map[string]any)
 	cs.ParseEnv(&actual, env)
 	assert.Equal(t, expected, actual, "CommandSet.ParseEnv() returned unexpected results")

--- a/config.go
+++ b/config.go
@@ -5,6 +5,7 @@ import (
 	"math"
 	"os"
 	"regexp"
+	"strconv"
 	"strings"
 
 	"gopkg.in/yaml.v3"
@@ -84,6 +85,26 @@ type ConfigInput struct {
 	Pattern      string
 	Options      ConfigInputOptions
 	Description  string
+}
+
+func (input *ConfigInput) Parse(s string) (any, bool) {
+	switch input.Type {
+	case "number":
+		if strings.Contains(s, ".") {
+			n, err := strconv.ParseFloat(s, 64)
+			return n, err == nil
+		} else {
+			n, err := strconv.ParseInt(s, 10, 64)
+			return n, err == nil
+		}
+	case "boolean":
+		b, err := strconv.ParseBool(s)
+		return b, err == nil
+	case "string":
+		return s, true
+	default:
+		return s, false
+	}
 }
 
 func (input *ConfigInput) SafeName() string {

--- a/config.go
+++ b/config.go
@@ -9,6 +9,11 @@ import (
 	"gopkg.in/yaml.v3"
 )
 
+var defaultBooleanOptions = ConfigInputOptions{
+	ConfigInputOption{Label: "yes", Value: true},
+	ConfigInputOption{Label: "no", Value: false},
+}
+
 type ConfigInputOption struct {
 	Label string
 	Value any
@@ -146,6 +151,13 @@ func (x *ConfigInputs) UnmarshalYAML(value *yaml.Node) error {
 
 		switch input.Type {
 		case "string":
+		case "boolean":
+			if input.DefaultValue == nil {
+				input.DefaultValue = false
+			}
+			if input.Options == nil {
+				input.Options = defaultBooleanOptions
+			}
 		case "":
 			input.Type = "string"
 		default:
@@ -296,6 +308,8 @@ func validValue(v any, t string) bool {
 	switch v.(type) {
 	case string:
 		return t == "string"
+	case bool:
+		return t == "boolean"
 	case nil:
 		return true
 	default:

--- a/config_test.go
+++ b/config_test.go
@@ -311,7 +311,7 @@ inputs:
 }
 
 func TestParseConfig_InputType(t *testing.T) {
-	t.Run("set type", func(t *testing.T) {
+	t.Run("valid string type", func(t *testing.T) {
 		content := `
 run: ok
 inputs:

--- a/config_test.go
+++ b/config_test.go
@@ -172,6 +172,7 @@ inputs:
 		Inputs: ConfigInputs{
 			ConfigInput{
 				Name: "foobar",
+				Type: "string",
 				Options: ConfigInputOptions{
 					{Label: "a", Value: "A"},
 					{Label: "b", Value: "B"},
@@ -198,6 +199,7 @@ inputs:
 		Inputs: ConfigInputs{
 			ConfigInput{
 				Name: "foobar",
+				Type: "string",
 				Options: ConfigInputOptions{
 					{Label: "A", Value: "A"},
 					{Label: "B", Value: "B"},
@@ -234,6 +236,7 @@ inputs:
 		Inputs: ConfigInputs{
 			ConfigInput{
 				Name:         "foobar",
+				Type:         "string",
 				DefaultValue: "Foobar",
 			},
 		},
@@ -275,6 +278,84 @@ inputs:
 	assert.EqualError(t, actual, expected, "ParseConfig() returned unexpected error")
 }
 
+func TestParseConfig_InputIsScalar(t *testing.T) {
+	t.Run("valid type", func(t *testing.T) {
+		content := `
+run: ok
+inputs:
+  foobar: string
+`
+		expected := Config{
+			Run: "ok",
+			Inputs: ConfigInputs{
+				ConfigInput{
+					Name: "foobar",
+					Type: "string",
+				},
+			},
+		}
+		actual, error := ParseConfig([]byte(content))
+		assert.NoError(t, error, "ParseConfig() returned unexpected error")
+		assert.Equal(t, expected, actual)
+	})
+	t.Run("invalid type", func(t *testing.T) {
+		content := `
+run: ok
+inputs:
+  foobar: unknown
+`
+		expected := "line 4: unsupported input type 'unknown'"
+		_, actual := ParseConfig([]byte(content))
+		assert.EqualError(t, actual, expected, "ParseConfig() returned unexpected error")
+	})
+}
+
+func TestParseConfig_InputType(t *testing.T) {
+	t.Run("set type", func(t *testing.T) {
+		content := `
+run: ok
+inputs:
+  foobar:
+    type: string
+`
+		expected := Config{
+			Run: "ok",
+			Inputs: ConfigInputs{
+				ConfigInput{
+					Name: "foobar",
+					Type: "string",
+				},
+			},
+		}
+		actual, error := ParseConfig([]byte(content))
+		assert.NoError(t, error, "ParseConfig() returned unexpected error")
+		assert.Equal(t, expected, actual)
+	})
+	t.Run("invalid string type", func(t *testing.T) {
+		content := `
+run: ok
+inputs:
+  foobar:
+    type: string
+    default: 123
+`
+		expected := "line 5: default value type mismatch"
+		_, actual := ParseConfig([]byte(content))
+		assert.EqualError(t, actual, expected, "ParseConfig() returned unexpected error")
+	})
+	t.Run("unsupported type", func(t *testing.T) {
+		content := `
+run: ok
+inputs:
+  foobar:
+    type: unknown
+`
+		expected := "line 5: unsupported input type 'unknown'"
+		_, actual := ParseConfig([]byte(content))
+		assert.EqualError(t, actual, expected, "ParseConfig() returned unexpected error")
+	})
+}
+
 func TestLoadConfig(t *testing.T) {
 	content := `
 commands:
@@ -296,6 +377,7 @@ commands:
 				Inputs: ConfigInputs{
 					{
 						Name: "sequence",
+						Type: "string",
 						Options: ConfigInputOptions{
 							{Label: "A", Value: "A"},
 							{Label: "B", Value: "B"},
@@ -303,6 +385,7 @@ commands:
 					},
 					{
 						Name: "map",
+						Type: "string",
 						Options: ConfigInputOptions{
 							{Label: "a", Value: "A"},
 							{Label: "b", Value: "B"},

--- a/config_test.go
+++ b/config_test.go
@@ -158,8 +158,9 @@ commands:
 	assert.EqualError(t, actual, expected, "ParseConfig() returned unexpected error")
 }
 
-func TestParseConfig_InputOptionsIsMap(t *testing.T) {
-	content := `
+func TestParseConfig_InputOptions(t *testing.T) {
+	t.Run("valid map", func(t *testing.T) {
+		content := `
 run: ok
 inputs:
   foobar:
@@ -167,26 +168,39 @@ inputs:
       a: A
       b: B
 `
-	expected := Config{
-		Run: "ok",
-		Inputs: ConfigInputs{
-			ConfigInput{
-				Name: "foobar",
-				Type: "string",
-				Options: ConfigInputOptions{
-					{Label: "a", Value: "A"},
-					{Label: "b", Value: "B"},
+		expected := Config{
+			Run: "ok",
+			Inputs: ConfigInputs{
+				ConfigInput{
+					Name: "foobar",
+					Type: "string",
+					Options: ConfigInputOptions{
+						{Label: "a", Value: "A"},
+						{Label: "b", Value: "B"},
+					},
 				},
 			},
-		},
-	}
-	actual, err := ParseConfig([]byte(content))
-	assert.NoError(t, err, "ParseConfig() returned unexpected error")
-	assert.Equal(t, expected, actual, "ParseConfig() returned unexpected error")
-}
-
-func TestParseConfig_InputOptionsIsSequence(t *testing.T) {
-	content := `
+		}
+		actual, err := ParseConfig([]byte(content))
+		assert.NoError(t, err, "ParseConfig() returned unexpected error")
+		assert.Equal(t, expected, actual, "ParseConfig() returned unexpected error")
+	})
+	t.Run("invalid map", func(t *testing.T) {
+		content := `
+run: ok
+inputs:
+  foobar:
+    type: string
+    options:
+      a: 1
+      b: 2
+`
+		expected := "line 5: option value type mismatch"
+		_, actual := ParseConfig([]byte(content))
+		assert.EqualError(t, actual, expected, "ParseConfig() returned unexpected error")
+	})
+	t.Run("valid sequence", func(t *testing.T) {
+		content := `
 run: ok
 inputs:
   foobar:
@@ -194,34 +208,48 @@ inputs:
       - A
       - B
 `
-	expected := Config{
-		Run: "ok",
-		Inputs: ConfigInputs{
-			ConfigInput{
-				Name: "foobar",
-				Type: "string",
-				Options: ConfigInputOptions{
-					{Label: "A", Value: "A"},
-					{Label: "B", Value: "B"},
+		expected := Config{
+			Run: "ok",
+			Inputs: ConfigInputs{
+				ConfigInput{
+					Name: "foobar",
+					Type: "string",
+					Options: ConfigInputOptions{
+						{Label: "A", Value: "A"},
+						{Label: "B", Value: "B"},
+					},
 				},
 			},
-		},
-	}
-	actual, err := ParseConfig([]byte(content))
-	assert.NoError(t, err, "ParseConfig() returned unexpected error")
-	assert.Equal(t, expected, actual, "ParseConfig() returned unexpected error")
-}
-
-func TestParseConfig_InputOptionsIsScaler(t *testing.T) {
-	content := `
+		}
+		actual, err := ParseConfig([]byte(content))
+		assert.NoError(t, err, "ParseConfig() returned unexpected error")
+		assert.Equal(t, expected, actual, "ParseConfig() returned unexpected error")
+	})
+	t.Run("invalid sequence", func(t *testing.T) {
+		content := `
+run: ok
+inputs:
+  foobar:
+    type: string
+    options:
+      - 1
+      - 2
+`
+		expected := "line 5: option value type mismatch"
+		_, actual := ParseConfig([]byte(content))
+		assert.EqualError(t, actual, expected, "ParseConfig() returned unexpected error")
+	})
+	t.Run("invalid scaler", func(t *testing.T) {
+		content := `
 run: ok
 inputs:
   foobar:
     options: ooops
 `
-	expected := "line 5: unexpected node type"
-	_, actual := ParseConfig([]byte(content))
-	assert.EqualError(t, actual, expected, "ParseConfig() returned unexpected error")
+		expected := "line 5: unexpected node type"
+		_, actual := ParseConfig([]byte(content))
+		assert.EqualError(t, actual, expected, "ParseConfig() returned unexpected error")
+	})
 }
 
 func TestParseConfig_InputsIsMap(t *testing.T) {

--- a/config_test.go
+++ b/config_test.go
@@ -371,6 +371,32 @@ inputs:
 		_, actual := ParseConfig([]byte(content))
 		assert.EqualError(t, actual, expected, "ParseConfig() returned unexpected error")
 	})
+	t.Run("valid boolean type", func(t *testing.T) {
+		content := `
+run: ok
+inputs:
+  foobar:
+    type: boolean
+    default: false
+`
+		expected := Config{
+			Run: "ok",
+			Inputs: ConfigInputs{
+				ConfigInput{
+					Name:         "foobar",
+					Type:         "boolean",
+					DefaultValue: false,
+					Options: ConfigInputOptions{
+						ConfigInputOption{Label: "yes", Value: true},
+						ConfigInputOption{Label: "no", Value: false},
+					},
+				},
+			},
+		}
+		actual, error := ParseConfig([]byte(content))
+		assert.NoError(t, error, "ParseConfig() returned unexpected error")
+		assert.Equal(t, expected, actual)
+	})
 	t.Run("unsupported type", func(t *testing.T) {
 		content := `
 run: ok
@@ -390,6 +416,7 @@ commands:
   test:
     run: go test
     inputs:
+      bool: boolean
       sequence:
         options: [A, B]
       map:
@@ -403,6 +430,15 @@ commands:
 				Name: "test",
 				Run:  "go test",
 				Inputs: ConfigInputs{
+					{
+						Name:         "bool",
+						Type:         "boolean",
+						DefaultValue: false,
+						Options: ConfigInputOptions{
+							{Label: "yes", Value: true},
+							{Label: "no", Value: false},
+						},
+					},
 					{
 						Name: "sequence",
 						Type: "string",

--- a/config_test.go
+++ b/config_test.go
@@ -41,6 +41,57 @@ func TestConfigInputSelectable(t *testing.T) {
 	assert.Equal(t, true, input.Selectable(), "ConfigInput.Selectable() with options expected to return true")
 }
 
+func TestConfigInputParse(t *testing.T) {
+	t.Run("number integer", func(t *testing.T) {
+		input := ConfigInput{Type: "number"}
+		result, ok := input.Parse("123")
+		assert.True(t, ok, "ConfigInput.Parse() failed to convert value")
+		assert.Equal(t, int64(123), result, "ConfigInput.Parse() returned unexpected result")
+	})
+	t.Run("number float", func(t *testing.T) {
+		input := ConfigInput{Type: "number"}
+		result, ok := input.Parse("12.3")
+		assert.True(t, ok, "ConfigInput.Parse() failed to convert value")
+		assert.Equal(t, float64(12.3), result, "ConfigInput.Parse() returned unexpected result")
+	})
+	t.Run("boolean true", func(t *testing.T) {
+		input := ConfigInput{Type: "boolean"}
+		result, ok := input.Parse("true")
+		assert.True(t, ok, "ConfigInput.Parse() failed to convert value")
+		assert.Equal(t, true, result, "ConfigInput.Parse() returned unexpected result")
+	})
+	t.Run("boolean false", func(t *testing.T) {
+		input := ConfigInput{Type: "boolean"}
+		result, ok := input.Parse("false")
+		assert.True(t, ok, "ConfigInput.Parse() failed to convert value")
+		assert.Equal(t, false, result, "ConfigInput.Parse() returned unexpected result")
+	})
+	t.Run("boolean one", func(t *testing.T) {
+		input := ConfigInput{Type: "boolean"}
+		result, ok := input.Parse("1")
+		assert.True(t, ok, "ConfigInput.Parse() failed to convert value")
+		assert.Equal(t, true, result, "ConfigInput.Parse() returned unexpected result")
+	})
+	t.Run("boolean zero", func(t *testing.T) {
+		input := ConfigInput{Type: "boolean"}
+		result, ok := input.Parse("0")
+		assert.True(t, ok, "ConfigInput.Parse() failed to convert value")
+		assert.Equal(t, false, result, "ConfigInput.Parse() returned unexpected result")
+	})
+	t.Run("string", func(t *testing.T) {
+		input := ConfigInput{Type: "string"}
+		result, ok := input.Parse("foobar")
+		assert.True(t, ok, "ConfigInput.Parse() failed to convert value")
+		assert.Equal(t, "foobar", result, "ConfigInput.Parse() returned unexpected result")
+	})
+	t.Run("unknown type", func(t *testing.T) {
+		input := ConfigInput{}
+		result, ok := input.Parse("foobar")
+		assert.False(t, ok, "ConfigInput.Parse() was expected to fail parsing")
+		assert.Equal(t, "foobar", result, "ConfigInput.Parse() returned unexpected result")
+	})
+}
+
 func TestConfigInputSafeName(t *testing.T) {
 	input := ConfigInput{
 		Name: "foo-bar",

--- a/prompt.go
+++ b/prompt.go
@@ -41,7 +41,7 @@ func selectCommand(command ConfigCommand) (ConfigCommand, error) {
 	}
 }
 
-func askInput(input ConfigInput) (string, error) {
+func askInput(input ConfigInput) (any, error) {
 	if input.Selectable() {
 		return selectInput(input)
 	} else {
@@ -49,7 +49,7 @@ func askInput(input ConfigInput) (string, error) {
 	}
 }
 
-func selectInput(input ConfigInput) (string, error) {
+func selectInput(input ConfigInput) (any, error) {
 	prompt := input.Description
 	if prompt == "" {
 		prompt = fmt.Sprintf("Choose a %s", termenv.String(input.Name).Underline().String())
@@ -67,7 +67,7 @@ func selectInput(input ConfigInput) (string, error) {
 	}
 }
 
-func getInput(input ConfigInput) (string, error) {
+func getInput(input ConfigInput) (any, error) {
 	prompt := input.Description
 	if prompt == "" {
 		prompt = fmt.Sprintf("Please specify a %s", termenv.String(input.Name).Underline().String())

--- a/prompt.go
+++ b/prompt.go
@@ -73,7 +73,7 @@ func getInput(input ConfigInput) (string, error) {
 		prompt = fmt.Sprintf("Please specify a %s", termenv.String(input.Name).Underline().String())
 	}
 	ti := textinput.New(prompt)
-	ti.InitialValue = input.DefaultValue
+	ti.InitialValue = fmt.Sprint(input.DefaultValue)
 	ti.Validate = func(value string) error {
 		if input.Valid(value) {
 			return nil

--- a/utils.go
+++ b/utils.go
@@ -2,6 +2,7 @@ package main
 
 import (
 	"fmt"
+	"math"
 	"strings"
 	"text/template"
 )
@@ -117,4 +118,31 @@ func DiffStrings(a, b []string) []string {
 		}
 	}
 	return diff
+}
+
+func ToFloat64(value any) float64 {
+	switch v := value.(type) {
+	case uint:
+		return float64(v)
+	case int:
+		return float64(v)
+	case uint16:
+		return float64(v)
+	case int16:
+		return float64(v)
+	case uint32:
+		return float64(v)
+	case int32:
+		return float64(v)
+	case uint64:
+		return float64(v)
+	case int64:
+		return float64(v)
+	case float32:
+		return float64(v)
+	case float64:
+		return v
+	default:
+		return math.NaN()
+	}
 }

--- a/utils_test.go
+++ b/utils_test.go
@@ -1,6 +1,7 @@
 package main
 
 import (
+	"math"
 	"testing"
 	"text/template"
 
@@ -72,4 +73,40 @@ func TestDiffStrings(t *testing.T) {
 	b := []string{"a"}
 	expected := []string{"b", "c"}
 	assert.Equal(t, expected, DiffStrings(a, b), "DiffStrings() returned unexpected results")
+}
+
+func TestToFloat64(t *testing.T) {
+	t.Run("int", func(t *testing.T) {
+		assert.Equal(t, float64(1), ToFloat64(int(1)), "toFloat64() returned unexpected result")
+	})
+	t.Run("uint", func(t *testing.T) {
+		assert.Equal(t, float64(1), ToFloat64(uint(1)), "toFloat64() returned unexpected result")
+	})
+	t.Run("int16", func(t *testing.T) {
+		assert.Equal(t, float64(1), ToFloat64(int16(1)), "toFloat64() returned unexpected result")
+	})
+	t.Run("uint16", func(t *testing.T) {
+		assert.Equal(t, float64(1), ToFloat64(uint16(1)), "toFloat64() returned unexpected result")
+	})
+	t.Run("int32", func(t *testing.T) {
+		assert.Equal(t, float64(1), ToFloat64(int32(1)), "toFloat64() returned unexpected result")
+	})
+	t.Run("uint32", func(t *testing.T) {
+		assert.Equal(t, float64(1), ToFloat64(uint32(1)), "toFloat64() returned unexpected result")
+	})
+	t.Run("int64", func(t *testing.T) {
+		assert.Equal(t, float64(1), ToFloat64(int64(1)), "toFloat64() returned unexpected result")
+	})
+	t.Run("uint64", func(t *testing.T) {
+		assert.Equal(t, float64(1), ToFloat64(uint64(1)), "toFloat64() returned unexpected result")
+	})
+	t.Run("float32", func(t *testing.T) {
+		assert.Equal(t, float64(1), ToFloat64(float32(1)), "toFloat64() returned unexpected result")
+	})
+	t.Run("float64", func(t *testing.T) {
+		assert.Equal(t, float64(1), ToFloat64(float64(1)), "toFloat64() returned unexpected result")
+	})
+	t.Run("string", func(t *testing.T) {
+		assert.True(t, math.IsNaN(ToFloat64("1")), "toFloat64() returned unexpected result")
+	})
 }


### PR DESCRIPTION
- **Add support for input type**
- **Make default value type agnostic**
- **Make input options value any type**
- **Add boolean type**
- **Update README to include boolean types**
- **Add number type**
- **Parse env vars into appropriate types**
- **Support numbers when parsing args and fix up defaults**
- **Update README about numbers**

## Description

Add support for specifying input types, such as `string`, `number`, and `boolean`. Also added additional configuration to validate numbers with `min` and `max`.

## Checklist

- [x] All tests are passing
- [x] New tests were created to address changes in pr (and tests are passing)
- [x] Updated README and/or documentation, if necessary

Thanks for contributing!
