### PR TITLE
Replay history

### DIFF
--- a/history.go
+++ b/history.go
@@ -1,0 +1,106 @@
+package main
+
+import (
+	"errors"
+	"os"
+	"path/filepath"
+	"reflect"
+
+	"gopkg.in/yaml.v3"
+)
+
+const (
+	DefaultHistoryFile      = ".ilc_history"
+	DefaultHistoryFilePerms = 0644
+)
+
+var ErrInvalidHistoryFile = errors.New("invalid history file")
+
+type History struct {
+	Records map[string][][]string
+	Path    string
+}
+
+func (h *History) Lookup(filepath string, args []string) ([]string, bool) {
+	entries, found := h.Records[filepath]
+	if !found {
+		return []string{}, false
+	}
+	argsLen := len(args)
+	for i := len(entries) - 1; i >= 0; i-- {
+		entry := entries[i]
+		entryLen := len(entry)
+		// Nothing to match so the latest record should be returned
+		// DeepEqual will match this case too but just saving some cycles
+		if entryLen == 0 {
+			return entry, true
+		}
+		// Skip if the entry is shorter than the args as it won't match
+		if entryLen < argsLen {
+			continue
+		}
+		subentry := entry[0:argsLen]
+		if reflect.DeepEqual(subentry, args) {
+			return entry, true
+		}
+	}
+	return []string{}, false
+}
+
+func (h *History) Append(filepath string, args []string) {
+	logger.Printf("Adding history entry for config %s\n", filepath)
+	entries := h.Records[filepath]
+	if !h.isLatestRecord(filepath, args) {
+		h.Records[filepath] = append(entries, args)
+	}
+}
+
+func (h *History) isLatestRecord(filepath string, args []string) bool {
+	entries := h.Records[filepath]
+	if entriesLen := len(entries); entriesLen > 0 {
+		return reflect.DeepEqual(entries[entriesLen-1], args)
+	}
+	return false
+}
+
+func (h *History) Save() error {
+	logger.Printf("Saving history to %s\n", h.Path)
+	content, err := yaml.Marshal(h.Records)
+	if err != nil {
+		return err
+	}
+	file, err := os.OpenFile(h.Path, os.O_CREATE|os.O_WRONLY, DefaultHistoryFilePerms)
+	if err != nil {
+		return err
+	}
+	defer file.Close()
+	file.Write(content)
+	return nil
+}
+
+func (h *History) load() error {
+	logger.Printf("Loading history from %s\n", h.Path)
+	if content, err := os.ReadFile(h.Path); err != nil {
+		return err
+	} else if err := yaml.Unmarshal(content, &h.Records); err != nil {
+		return err
+	} else {
+		return nil
+	}
+}
+
+func LoadHistory(path string) (History, error) {
+	if path == "" {
+		if userHome, err := os.UserHomeDir(); err != nil {
+			path = DefaultHistoryFile
+		} else {
+			path = filepath.Join(userHome, DefaultHistoryFile)
+		}
+	}
+	history := History{
+		Path:    path,
+		Records: make(map[string][][]string),
+	}
+	err := history.load()
+	return history, err
+}

--- a/history_test.go
+++ b/history_test.go
@@ -1,0 +1,188 @@
+package main
+
+import (
+	"os"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestHistoryLookup(t *testing.T) {
+	history := History{
+		Records: map[string][][]string{
+			"some file1": {
+				[]string{"arg1", "arg2", "arg3"},
+				[]string{"arg1"},
+				[]string{"arg1", "arg2 arg3"},
+			},
+			"some file2": {
+				[]string{"arg1", "arg2"},
+			},
+		},
+	}
+	t.Run("when has no config record", func(t *testing.T) {
+		expected := []string{}
+		actual, found := history.Lookup("some file3", []string{"arg1"})
+		assert.False(t, found)
+		assert.Equal(t, expected, actual)
+	})
+	t.Run("when query args do not match", func(t *testing.T) {
+		expected := []string{}
+		actual, found := history.Lookup("some file1", []string{"arg1", "arg2", "arg3", "arg4"})
+		assert.False(t, found)
+		assert.Equal(t, expected, actual)
+	})
+	t.Run("when query args do match all", func(t *testing.T) {
+		expected := []string{"arg1", "arg2", "arg3"}
+		actual, found := history.Lookup("some file1", []string{"arg1", "arg2", "arg3"})
+		assert.True(t, found)
+		assert.Equal(t, expected, actual)
+	})
+	t.Run("when query args do match some", func(t *testing.T) {
+		expected := []string{"arg1", "arg2", "arg3"}
+		actual, found := history.Lookup("some file1", []string{"arg1", "arg2"})
+		assert.True(t, found)
+		assert.Equal(t, expected, actual)
+	})
+	t.Run("when query args are empty", func(t *testing.T) {
+		expected := []string{"arg1", "arg2 arg3"}
+		actual, found := history.Lookup("some file1", []string{})
+		assert.True(t, found)
+		assert.Equal(t, expected, actual)
+	})
+}
+
+func TestHistoryAppend(t *testing.T) {
+	actual := History{
+		Records: map[string][][]string{
+			"some file1": {
+				[]string{"arg1", "arg2", "arg3"},
+				[]string{"arg1"},
+			},
+			"some file2": {
+				[]string{"arg1", "arg2"},
+			},
+		},
+	}
+	expected := History{
+		Records: map[string][][]string{
+			"some file1": {
+				[]string{"arg1", "arg2", "arg3"},
+				[]string{"arg1"},
+			},
+			"some file2": {
+				[]string{"arg1", "arg2"},
+			},
+			"some file3": {
+				[]string{"arg1", "arg2"},
+			},
+		},
+	}
+	actual.Append("some file3", []string{"arg1", "arg2"})
+	assert.Equal(t, expected, actual)
+	actual.Append("some file3", []string{"arg1", "arg2"})
+	assert.Equal(t, expected, actual)
+}
+
+func TestHistorySave(t *testing.T) {
+	tempFile, err := os.CreateTemp(t.TempDir(), "")
+	assert.NoError(t, err, "Failed to create temp file")
+
+	history := History{
+		Path: tempFile.Name(),
+		Records: map[string][][]string{
+			"some file1": {
+				[]string{"arg1", "arg2", "arg3"},
+				[]string{"arg1"},
+				[]string{"arg1", "arg2", "arg3"},
+			},
+			"some file2": {
+				[]string{"arg1", "arg2"},
+			},
+		},
+	}
+	expected := `some file1:
+    - - arg1
+      - arg2
+      - arg3
+    - - arg1
+    - - arg1
+      - arg2
+      - arg3
+some file2:
+    - - arg1
+      - arg2
+`
+	err = history.Save()
+	assert.NoError(t, err)
+	actual, err := os.ReadFile(tempFile.Name())
+	assert.NoError(t, err)
+	assert.Equal(t, expected, string(actual))
+}
+
+func TestLoadHistory(t *testing.T) {
+	t.Run("empty file", func(t *testing.T) {
+		tempFile, err := os.CreateTemp(t.TempDir(), "")
+		assert.NoError(t, err, "Failed to create temp file")
+
+		expected := History{
+			Path:    tempFile.Name(),
+			Records: make(map[string][][]string),
+		}
+		actual, err := LoadHistory(tempFile.Name())
+		assert.NoError(t, err)
+		assert.Equal(t, expected, actual)
+	})
+	t.Run("invalid file", func(t *testing.T) {
+		content := `
+  arg1 arg2 arg3
+some file:
+  arg1 arg2
+`
+		tempFile, err := os.CreateTemp(t.TempDir(), "")
+		assert.NoError(t, err, "Failed to create temp file")
+
+		_, err = tempFile.Write([]byte(content))
+		assert.NoError(t, err, "Failed to write config to temp file")
+
+		expected := History{
+			Path:    tempFile.Name(),
+			Records: make(map[string][][]string),
+		}
+		actual, err := LoadHistory(tempFile.Name())
+		assert.Error(t, err)
+		assert.Equal(t, expected, actual)
+	})
+	t.Run("valid file", func(t *testing.T) {
+		content := `
+# comment
+some file1:
+  - [arg1, arg2, arg3]
+  - [arg1]
+
+some file2:
+  - [arg1, arg2]
+`
+		tempFile, err := os.CreateTemp(t.TempDir(), "")
+		assert.NoError(t, err, "Failed to create temp file")
+
+		_, err = tempFile.Write([]byte(content))
+		assert.NoError(t, err, "Failed to write config to temp file")
+
+		expected := History{
+			Path: tempFile.Name(),
+			Records: map[string][][]string{
+				"some file1": {
+					[]string{"arg1", "arg2", "arg3"},
+					[]string{"arg1"},
+				},
+				"some file2": {
+					[]string{"arg1", "arg2"},
+				},
+			},
+		}
+		actual, err := LoadHistory(tempFile.Name())
+		assert.NoError(t, err)
+		assert.Equal(t, expected, actual)
+	})
+}

--- a/input_test.go
+++ b/input_test.go
@@ -300,3 +300,15 @@ func TestInputsToEnvMap(t *testing.T) {
 	actual := inputs.ToEnvMap()
 	assert.Equal(t, expected, actual)
 }
+
+func TestInputsToArgs(t *testing.T) {
+	inputs := Inputs{
+		Input{Name: "s", Value: &StringValue{Value: "s"}},
+		Input{Name: "n", Value: &NumberValue{Value: 1.0}},
+		Input{Name: "t", Value: &BooleanValue{Value: true}},
+		Input{Name: "f", Value: &BooleanValue{Value: false}},
+	}
+	expected := []string{"-s", "s", "-n", "1", "-t", "-f=false"}
+	actual := inputs.ToArgs()
+	assert.Equal(t, expected, actual)
+}

--- a/runner.go
+++ b/runner.go
@@ -125,9 +125,6 @@ func (r *Runner) getInputValuesFromEnv(inputs Inputs) map[string]string {
 
 func (r *Runner) run() error {
 	var err error
-	if r.NonInteractive {
-		logger.Println("Running in non-interactive mode")
-	}
 	selected, args := r.Config.Select(r.Args)
 	var inputs Inputs
 	var values map[string]any
@@ -204,6 +201,9 @@ func (r *Runner) Run() error {
 	if r.ValidateConfig {
 		r.Printf("configuration is valid\n")
 		return nil
+	}
+	if r.NonInteractive {
+		logger.Println("Running in non-interactive mode")
 	}
 	return r.run()
 }

--- a/runner_test.go
+++ b/runner_test.go
@@ -1,0 +1,27 @@
+package main
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestRunnerGetInputValuesFromEnv(t *testing.T) {
+	runner := Runner{
+		Env: EnvMap{
+			"ILC_INPUT_foo_bar": "foobar",
+			"ILC_INPUT_foobar":  "nope",
+			"ILC_INPUT_num_ber": "10",
+			"TEST":              "true",
+		},
+	}
+	expected := map[string]string{
+		"foo-bar": "foobar",
+		"num_ber": "10",
+	}
+	actual := runner.getInputValuesFromEnv(Inputs{
+		{Name: "foo-bar", Value: &StringValue{}},
+		{Name: "num_ber", Value: &NumberValue{}},
+	})
+	assert.Equal(t, expected, actual)
+}

--- a/runner_test.go
+++ b/runner_test.go
@@ -25,3 +25,13 @@ func TestRunnerGetInputValuesFromEnv(t *testing.T) {
 	})
 	assert.Equal(t, expected, actual)
 }
+
+func TestRunnerIsReplay(t *testing.T) {
+	runner := Runner{}
+	runner.Args = []string{"arg1", "arg2"}
+	assert.False(t, runner.isReplay())
+	runner.Args = []string{"!arg1", "arg2"}
+	assert.True(t, runner.isReplay())
+	runner.Args = []string{"!", "arg1", "arg2"}
+	assert.True(t, runner.isReplay())
+}

--- a/selection.go
+++ b/selection.go
@@ -161,3 +161,14 @@ func (commands Selection) Cmd(data TemplateData, moreEnv EnvMap) (*exec.Cmd, err
 	cmd.Env = env.ToList()
 	return cmd, nil
 }
+
+func (commands Selection) ToArgs() []string {
+	inputArgs := commands.Inputs().ToArgs()
+	args := make([]string, 0, len(commands)+len(inputArgs))
+	for _, command := range commands {
+		if command.Name != "" {
+			args = append(args, command.Name)
+		}
+	}
+	return append(args, inputArgs...)
+}

--- a/selection_test.go
+++ b/selection_test.go
@@ -470,6 +470,34 @@ func TestSelectionCmd(t *testing.T) {
 	})
 }
 
+func TestSelectionToArgs(t *testing.T) {
+	commands := Selection{
+		{
+			Name: "",
+			Inputs: Inputs{
+				{Name: "arg1", Value: &StringValue{Value: "foobar"}},
+				{Name: "arg2", Value: &NumberValue{Value: 123}},
+			},
+		},
+		{
+			Name: "command1",
+			Inputs: Inputs{
+				{Name: "arg1", Value: &StringValue{Value: "foobar"}},
+				{Name: "arg2", Value: &NumberValue{Value: 123}},
+			},
+		},
+		{
+			Name: "command2",
+			Inputs: Inputs{
+				{Name: "arg3", Value: &BooleanValue{Value: true}},
+			},
+		},
+	}
+	expected := []string{"command1", "command2", "-arg1", "foobar", "-arg2", "123", "-arg3"}
+	actual := commands.ToArgs()
+	assert.Equal(t, expected, actual)
+}
+
 func readTextFile(name string) (string, error) {
 	var str strings.Builder
 	data, err := os.ReadFile(name)


### PR DESCRIPTION
- **Add test for runner**
- **Add history store**
- **Add ability replay a previous command**

## Description

Add ability to replay a previously executed command. This works similar to how it operates in bash etc.

Example:

```shell
# Run a command, with arguments or interactively
ilc examples/ilc.yml weather -airport bne

# Run the last executed command
ilc examples/ilc.yml !

# or replay the matching command
ilc examples/ilc.yml !weather
```

## Checklist

- [x] All tests are passing
- [x] New tests were created to address changes in pr (and tests are passing)
- [x] Updated README and/or documentation, if necessary

Thanks for contributing!
