### PR TITLE
Enhance input options and documentation for boolean configurations

### DIFF
--- a/README.md
+++ b/README.md
@@ -161,6 +161,15 @@ inputs:
       - January
       - February
       - March
+      - April
+      - May
+      - June
+      - July
+      - August
+      - September
+      - October
+      - November
+      - December
 ```
 
 **Boolean options list:**

--- a/README.md
+++ b/README.md
@@ -183,9 +183,22 @@ inputs:
 
 - Customizing `boolean` input options:
 
-  For `boolean` inputs, options can be defined as a map to specify custom labels for `true` and `false` values, or as a 2-item array where the first item (index 0) represents `false` and the second item (index 1) represents `true`:
+  For `boolean` inputs, options can be defined as a 2-item array where the first item (index 0) represents `false` and the second item (index 1) represents `true`, or as a map. 
 
-  **Using a map:**
+  To keep maps fully consistent with standard selectable maps, keys are treated as user-facing labels and values as the resulting boolean value. For convenience, writing maps with the boolean as the key and the label as the value is also supported.
+
+  **Using a map (consistent with standard selectable maps):**
+
+  ```yaml
+  inputs:
+    confirm:
+      type: boolean
+      options:
+        Absolutely: true
+        No way: false
+  ```
+
+  **Using a map (alternative shorthand):**
 
   ```yaml
   inputs:

--- a/README.md
+++ b/README.md
@@ -181,6 +181,32 @@ inputs:
       Sydney: syd
 ```
 
+- Customizing `boolean` input options:
+
+  For `boolean` inputs, options can be defined as a map to specify custom labels for `true` and `false` values, or as a 2-item array where the first item (index 0) represents `false` and the second item (index 1) represents `true`:
+
+  **Using a map:**
+
+  ```yaml
+  inputs:
+    confirm:
+      type: boolean
+      options:
+        true: Absolutely
+        false: No way
+  ```
+
+  **Using an array:**
+
+  ```yaml
+  inputs:
+    confirm:
+      type: boolean
+      options:
+        - No way
+        - Absolutely
+  ```
+
 ### `inputs.<input_name>.pattern`
 
 A regex pattern to validate the input's value. Default is to allow any input.

--- a/README.md
+++ b/README.md
@@ -66,6 +66,7 @@ prompt will appear to complete the selection process.
 ### Inputs
 
 After a command is specified or selected, if any inputs are missing, an interactive TUI prompt will collect them before execution. Inputs are rendered natively according to their type:
+
 - **`boolean`**: Rendered as interactive selection toggles (Yes/No).
 - **`number`**: Can be incremented or decremented using arrow keys, enforcing `min` and `max` constraints.
 - **`string` (with `options`)**: Rendered as an interactive select list.
@@ -144,14 +145,15 @@ Optionally describe the input's purpose or outcome.
 
 ### `inputs.<input_name>.options`
 
-Limit the value to a list of acceptable values. Options can be a list of values
-or a map, with the keys presented as labels and the corresponding values the
-resulting value.
+Limit the value to a set of acceptable choices. Options can be defined as either a **list** or a **map**, with behavior varying slightly based on the input type:
 
-#### Example of option types
+#### 1. Using Lists (Arrays)
+- **String inputs**: The list items are presented directly as selectable options.
+- **Boolean inputs**: The list must contain exactly 2 items; the item at index 0 represents `false` and the item at index 1 represents `true`.
 
-- A list of options:
+##### List Examples
 
+**String options list:**
 ```yaml
 inputs:
   month:
@@ -159,19 +161,25 @@ inputs:
       - January
       - February
       - March
-      - April
-      - May
-      - June
-      - July
-      - August
-      - September
-      - October
-      - November
-      - December
 ```
 
-- A map of options:
+**Boolean options list:**
+```yaml
+inputs:
+  confirm:
+    type: boolean
+    options:
+      - No way      # index 0 (false)
+      - Absolutely  # index 1 (true)
+```
 
+#### 2. Using Maps
+- **Standard Behavior**: In general (and for string inputs), keys are presented as the user-facing labels, and the corresponding values are the resulting values.
+- **Boolean inputs**: Follows the standard `Label: Value` format for consistency, but also supports the shorthand `Value: Label` format for convenience.
+
+##### Map Examples
+
+**String options map:**
 ```yaml
 inputs:
   city:
@@ -181,44 +189,26 @@ inputs:
       Sydney: syd
 ```
 
-- Customizing `boolean` input options:
+**Boolean options map (Consistent style):**
+```yaml
+inputs:
+  confirm:
+    type: boolean
+    options:
+      Absolutely: true
+      No way: false
+```
 
-  For `boolean` inputs, options can be defined as a 2-item array where the first item (index 0) represents `false` and the second item (index 1) represents `true`, or as a map. 
+**Boolean options map (Shorthand style):**
+```yaml
+inputs:
+  confirm:
+    type: boolean
+    options:
+      true: Absolutely
+      false: No way
+```
 
-  To keep maps fully consistent with standard selectable maps, keys are treated as user-facing labels and values as the resulting boolean value. For convenience, writing maps with the boolean as the key and the label as the value is also supported.
-
-  **Using a map (consistent with standard selectable maps):**
-
-  ```yaml
-  inputs:
-    confirm:
-      type: boolean
-      options:
-        Absolutely: true
-        No way: false
-  ```
-
-  **Using a map (alternative shorthand):**
-
-  ```yaml
-  inputs:
-    confirm:
-      type: boolean
-      options:
-        true: Absolutely
-        false: No way
-  ```
-
-  **Using an array:**
-
-  ```yaml
-  inputs:
-    confirm:
-      type: boolean
-      options:
-        - No way
-        - Absolutely
-  ```
 
 ### `inputs.<input_name>.pattern`
 

--- a/examples/docker-manager.yml
+++ b/examples/docker-manager.yml
@@ -17,6 +17,9 @@ commands:
         description: Stream logs continuously
         type: boolean
         default: true
+        options:
+          - no
+          - yes
     run: docker logs {{ if .Input.follow }}-f{{ end }} --tail {{ .Input.lines }} {{ .Input.container }}
   cleanup:
     description: Clean up system resources

--- a/internal/ilc/prompt.go
+++ b/internal/ilc/prompt.go
@@ -74,10 +74,17 @@ func (m *commandModel) initCurrentInput() {
 	} else {
 		m.optionsIndex = 0
 		if m.isBooleanInput(current) {
+			opts := m.getBooleanOptions(current)
+			targetVal := "false"
 			if boolVal, ok := current.Value.(*inputs.BooleanValue); ok && boolVal.Value {
-				m.optionsIndex = 0
-			} else {
-				m.optionsIndex = 1
+				targetVal = "true"
+			}
+			m.optionsIndex = 0
+			for i, opt := range opts {
+				if opt.Value == targetVal {
+					m.optionsIndex = i
+					break
+				}
 			}
 		}
 	}

--- a/internal/ilc/yaml.go
+++ b/internal/ilc/yaml.go
@@ -143,6 +143,47 @@ func (x *yamlInput) UnmarshalYAML(node *yaml.Node) error {
 		}
 	}
 
+	if _, isBool := val.(*inputs.BooleanValue); isBool && len(temp.Options) > 0 {
+		var optionsNode *yaml.Node
+		for i := 0; i < len(node.Content); i += 2 {
+			if node.Content[i].Value == "options" {
+				optionsNode = node.Content[i+1]
+				break
+			}
+		}
+
+		if optionsNode != nil {
+			if optionsNode.Kind == yaml.SequenceNode {
+				if len(temp.Options) != 2 {
+					return fmt.Errorf("line %d: boolean input options array must have exactly 2 items, got %d", optionsNode.Line, len(temp.Options))
+				}
+				temp.Options[0] = inputs.InputOption{Label: temp.Options[0].Label, Value: "false"}
+				temp.Options[1] = inputs.InputOption{Label: temp.Options[1].Label, Value: "true"}
+			} else {
+				hasTrue := false
+				hasFalse := false
+				var newOptions yamlInputOptions
+				for _, opt := range temp.Options {
+					key := opt.Label
+					valStr := opt.Value
+					if key == "true" {
+						hasTrue = true
+						newOptions = append(newOptions, inputs.InputOption{Label: valStr, Value: "true"})
+					} else if key == "false" {
+						hasFalse = true
+						newOptions = append(newOptions, inputs.InputOption{Label: valStr, Value: "false"})
+					} else {
+						return fmt.Errorf("line %d: invalid boolean option key: %s (must be true or false)", optionsNode.Line, key)
+					}
+				}
+				if !hasTrue || !hasFalse {
+					return fmt.Errorf("line %d: boolean option map must contain both true and false keys", optionsNode.Line)
+				}
+				temp.Options = newOptions
+			}
+		}
+	}
+
 	x.Description = temp.Description
 	x.Options = temp.Options
 	x.Value = val

--- a/internal/ilc/yaml.go
+++ b/internal/ilc/yaml.go
@@ -166,14 +166,24 @@ func (x *yamlInput) UnmarshalYAML(node *yaml.Node) error {
 				for _, opt := range temp.Options {
 					key := opt.Label
 					valStr := opt.Value
-					if key == "true" {
-						hasTrue = true
-						newOptions = append(newOptions, inputs.InputOption{Label: valStr, Value: "true"})
-					} else if key == "false" {
-						hasFalse = true
-						newOptions = append(newOptions, inputs.InputOption{Label: valStr, Value: "false"})
+					if key == "true" || key == "false" {
+						if key == "true" {
+							hasTrue = true
+							newOptions = append(newOptions, inputs.InputOption{Label: valStr, Value: "true"})
+						} else {
+							hasFalse = true
+							newOptions = append(newOptions, inputs.InputOption{Label: valStr, Value: "false"})
+						}
+					} else if valStr == "true" || valStr == "false" {
+						if valStr == "true" {
+							hasTrue = true
+							newOptions = append(newOptions, inputs.InputOption{Label: key, Value: "true"})
+						} else {
+							hasFalse = true
+							newOptions = append(newOptions, inputs.InputOption{Label: key, Value: "false"})
+						}
 					} else {
-						return fmt.Errorf("line %d: invalid boolean option key: %s (must be true or false)", optionsNode.Line, key)
+						return fmt.Errorf("line %d: invalid boolean option: key='%s', value='%s' (one must be true or false)", optionsNode.Line, key, valStr)
 					}
 				}
 				if !hasTrue || !hasFalse {

--- a/internal/ilc/yaml_test.go
+++ b/internal/ilc/yaml_test.go
@@ -193,4 +193,90 @@ empty_input:
 		assert.NoError(t, err)
 		assert.Equal(t, expected, actual)
 	})
+	t.Run("boolean options map", func(t *testing.T) {
+		content := `
+bool_map:
+  type: boolean
+  options:
+    true: Absolutely
+    false: No way
+`
+		expected := func() Inputs {
+			fs := inputs.NewFlagSet("ilc", EnvVarPrefix)
+			fs.Var(&inputs.Input{
+				Name:  "bool_map",
+				Value: &inputs.BooleanValue{},
+				Options: inputs.InputOptions{
+					{Label: "Absolutely", Value: "true"},
+					{Label: "No way", Value: "false"},
+				},
+			})
+			return Inputs{FlagSet: fs}
+		}()
+		var actual Inputs
+		err := yaml.Unmarshal([]byte(content), &actual)
+		assert.NoError(t, err)
+		assert.Equal(t, expected, actual)
+	})
+	t.Run("boolean options array", func(t *testing.T) {
+		content := `
+bool_array:
+  type: boolean
+  options:
+    - No way
+    - Absolutely
+`
+		expected := func() Inputs {
+			fs := inputs.NewFlagSet("ilc", EnvVarPrefix)
+			fs.Var(&inputs.Input{
+				Name:  "bool_array",
+				Value: &inputs.BooleanValue{},
+				Options: inputs.InputOptions{
+					{Label: "No way", Value: "false"},
+					{Label: "Absolutely", Value: "true"},
+				},
+			})
+			return Inputs{FlagSet: fs}
+		}()
+		var actual Inputs
+		err := yaml.Unmarshal([]byte(content), &actual)
+		assert.NoError(t, err)
+		assert.Equal(t, expected, actual)
+	})
+	t.Run("boolean options invalid mapping", func(t *testing.T) {
+		content := `
+bool_invalid:
+  type: boolean
+  options:
+    true: Absolutely
+    invalid: No way
+`
+		var actual Inputs
+		err := yaml.Unmarshal([]byte(content), &actual)
+		assert.ErrorContains(t, err, "invalid boolean option key: invalid")
+	})
+	t.Run("boolean options incomplete mapping", func(t *testing.T) {
+		content := `
+bool_incomplete:
+  type: boolean
+  options:
+    true: Absolutely
+`
+		var actual Inputs
+		err := yaml.Unmarshal([]byte(content), &actual)
+		assert.ErrorContains(t, err, "boolean option map must contain both true and false keys")
+	})
+	t.Run("boolean options invalid array length", func(t *testing.T) {
+		content := `
+bool_invalid_array:
+  type: boolean
+  options:
+    - No
+    - Yes
+    - Maybe
+`
+		var actual Inputs
+		err := yaml.Unmarshal([]byte(content), &actual)
+		assert.ErrorContains(t, err, "boolean input options array must have exactly 2 items, got 3")
+	})
 }

--- a/internal/ilc/yaml_test.go
+++ b/internal/ilc/yaml_test.go
@@ -218,6 +218,31 @@ bool_map:
 		assert.NoError(t, err)
 		assert.Equal(t, expected, actual)
 	})
+	t.Run("boolean options map consistent", func(t *testing.T) {
+		content := `
+bool_map_consistent:
+  type: boolean
+  options:
+    Absolutely: true
+    No way: false
+`
+		expected := func() Inputs {
+			fs := inputs.NewFlagSet("ilc", EnvVarPrefix)
+			fs.Var(&inputs.Input{
+				Name:  "bool_map_consistent",
+				Value: &inputs.BooleanValue{},
+				Options: inputs.InputOptions{
+					{Label: "Absolutely", Value: "true"},
+					{Label: "No way", Value: "false"},
+				},
+			})
+			return Inputs{FlagSet: fs}
+		}()
+		var actual Inputs
+		err := yaml.Unmarshal([]byte(content), &actual)
+		assert.NoError(t, err)
+		assert.Equal(t, expected, actual)
+	})
 	t.Run("boolean options array", func(t *testing.T) {
 		content := `
 bool_array:
@@ -253,7 +278,7 @@ bool_invalid:
 `
 		var actual Inputs
 		err := yaml.Unmarshal([]byte(content), &actual)
-		assert.ErrorContains(t, err, "invalid boolean option key: invalid")
+		assert.ErrorContains(t, err, "invalid boolean option: key='invalid'")
 	})
 	t.Run("boolean options incomplete mapping", func(t *testing.T) {
 		content := `

--- a/internal/inputs/tui.go
+++ b/internal/inputs/tui.go
@@ -39,10 +39,17 @@ func (m *tuiModel) initCurrentInput() {
 	} else {
 		m.optionsIndex = 0
 		if m.isBooleanInput(current) {
+			opts := m.getBooleanOptions(current)
+			targetVal := "false"
 			if boolVal, ok := current.Value.(*BooleanValue); ok && boolVal.Value {
-				m.optionsIndex = 0
-			} else {
-				m.optionsIndex = 1
+				targetVal = "true"
+			}
+			m.optionsIndex = 0
+			for i, opt := range opts {
+				if opt.Value == targetVal {
+					m.optionsIndex = i
+					break
+				}
 			}
 		}
 	}

--- a/internal/inputs/tui_test.go
+++ b/internal/inputs/tui_test.go
@@ -103,6 +103,64 @@ func TestTuiModel_BooleanInputToggle(t *testing.T) {
 	assert.True(t, boolVal.Value)
 }
 
+func TestTuiModel_BooleanInputToggle_CustomOptions(t *testing.T) {
+	t.Run("array custom options", func(t *testing.T) {
+		boolVal := &BooleanValue{Value: true}
+		input := &Input{
+			Name:  "confirm",
+			Value: boolVal,
+			Options: InputOptions{
+				{Label: "No", Value: "false"},
+				{Label: "Yes", Value: "true"},
+			},
+		}
+		m := &tuiModel{
+			inputs:       []*Input{input},
+			currentIndex: 0,
+		}
+		m.initCurrentInput()
+
+		// Initial selection should be "true" (index 1 in our options: Yes is true)
+		assert.Equal(t, 1, m.optionsIndex)
+
+		// Press KeyUp to cycle to "false" (index 0: No is false)
+		_, _ = m.Update(tea.KeyMsg{Type: tea.KeyUp})
+		assert.Equal(t, 0, m.optionsIndex)
+
+		// Confirm "false" selection by pressing KeyEnter
+		_, _ = m.Update(tea.KeyMsg{Type: tea.KeyEnter})
+		assert.False(t, boolVal.Value)
+	})
+
+	t.Run("map custom options", func(t *testing.T) {
+		boolVal := &BooleanValue{Value: false}
+		input := &Input{
+			Name:  "confirm",
+			Value: boolVal,
+			Options: InputOptions{
+				{Label: "Absolutely", Value: "true"},
+				{Label: "No way", Value: "false"},
+			},
+		}
+		m := &tuiModel{
+			inputs:       []*Input{input},
+			currentIndex: 0,
+		}
+		m.initCurrentInput()
+
+		// Initial selection should be "false" (index 1 in our options: No way is false)
+		assert.Equal(t, 1, m.optionsIndex)
+
+		// Press KeyDown to cycle to "true" (index 0: Absolutely is true)
+		_, _ = m.Update(tea.KeyMsg{Type: tea.KeyDown})
+		assert.Equal(t, 0, m.optionsIndex)
+
+		// Confirm "true" selection by pressing KeyEnter
+		_, _ = m.Update(tea.KeyMsg{Type: tea.KeyEnter})
+		assert.True(t, boolVal.Value)
+	})
+}
+
 func TestTuiModel_Init(t *testing.T) {
 	m := &tuiModel{}
 	cmd := m.Init()


### PR DESCRIPTION
This pull request adds robust support for custom boolean input options in both YAML configuration and the TUI, allowing boolean prompts to present user-defined labels for true/false values. It also updates documentation and tests to cover these new behaviors, ensuring both flexibility and validation for boolean input options.

### Boolean input options enhancements

* Added support for specifying boolean input options as either a list (array) or map in YAML, with clear validation: lists must have exactly two items (index 0 = false, index 1 = true), and maps must include both true and false values, supporting both `Label: Value` and `Value: Label` formats.
* Updated TUI initialization logic in both `internal/ilc/prompt.go` and `internal/inputs/tui.go` to correctly set the selected option index for boolean inputs based on their value and the provided custom options. [[1]](diffhunk://#diff-345d23de86d87c7fd65db403bbc2e45eae7e3a477ba879a4610fa42d7765b209R77-R87) [[2]](diffhunk://#diff-907b7c0cf3ea0333bcf767f29c55c37a63733db96df7d9d74161f00bd6099ebeR42-R52)
* Extended tests to cover all new boolean options behaviors, including valid/invalid configurations and user interaction in the TUI. [[1]](diffhunk://#diff-990081e65e22790961efab3f94b3ca0fb4698adf931b27b1f37cec4b0cf236a2R196-R306) [[2]](diffhunk://#diff-c96b8c82d8bd657f7099d6a7a39371c5939cd9cca6827ec52563296447c4a9beR106-R163)

### Documentation updates

* Improved the `README.md` to clearly document the new boolean options syntax for both lists and maps, with detailed examples for each case. [[1]](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5L147-R156) [[2]](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5L173-R191) [[3]](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5R201-R221)

### Example configuration

* Updated the `examples/docker-manager.yml` to demonstrate usage of custom boolean options in a real command scenario.