### PR TITLE
Improve command description handling and command selection UI

### DIFF
--- a/internal/ilc/config.go
+++ b/internal/ilc/config.go
@@ -2,11 +2,23 @@ package ilc
 
 import (
 	"os"
+	"strings"
 
 	"gopkg.in/yaml.v3"
 )
 
 type Config Command
+
+func (config *Config) UnmarshalYAML(node *yaml.Node) error {
+	type tempConfig Config
+	var temp tempConfig
+	if err := node.Decode(&temp); err != nil {
+		return err
+	}
+	*config = Config(temp)
+	config.Description = strings.TrimSpace(config.Description)
+	return nil
+}
 
 func (config Config) Select(args []string) Selection {
 	selected := NewSelection(Command(config))

--- a/internal/ilc/config_test.go
+++ b/internal/ilc/config_test.go
@@ -212,3 +212,39 @@ func TestLoadConfig_FileNotExist(t *testing.T) {
 	assert.Error(t, err)
 }
 
+func TestLoadConfig_DescriptionTrimming(t *testing.T) {
+	content := `
+description: |
+  Root command description with newlines.
+
+commands:
+  test:
+    description: |
+      Subcommand description with newlines.
+      
+    run: go test
+    inputs:
+      test_input:
+        description: |
+          Input description with newlines.
+          
+        type: string
+`
+	tempFile, err := os.CreateTemp("", "")
+	assert.NoError(t, err)
+	defer os.Remove(tempFile.Name())
+
+	_, err = tempFile.Write([]byte(content))
+	assert.NoError(t, err)
+
+	actual, err := LoadConfig(tempFile.Name())
+	assert.NoError(t, err)
+
+	assert.Equal(t, "Root command description with newlines.", actual.Description)
+	assert.Equal(t, "Subcommand description with newlines.", actual.Commands[0].Description)
+
+	inputs := actual.Commands[0].Inputs.Inputs()
+	assert.Len(t, inputs, 1)
+	assert.Equal(t, "Input description with newlines.", inputs[0].Description)
+}
+

--- a/internal/ilc/prompt.go
+++ b/internal/ilc/prompt.go
@@ -312,7 +312,7 @@ func (m *commandModel) View() string {
 
 	var sb strings.Builder
 
-	sb.WriteString(titleStyle.Render(fmt.Sprintf("── %s ──", m.title)) + "\n\n")
+	sb.WriteString(titleStyle.Render(m.title) + "\n\n")
 
 	sb.WriteString(titleStyle.Render("Command:"))
 	if bcPlain.Len() > 0 {
@@ -341,19 +341,26 @@ func (m *commandModel) View() string {
 			}
 			padding := strings.Repeat(" ", padLen+5)
 
+			var cleanDesc string
+			if sub.Description != "" {
+				cleanDesc = strings.ReplaceAll(sub.Description, "\r", "")
+				cleanDesc = strings.ReplaceAll(cleanDesc, "\n", " ")
+				cleanDesc = strings.TrimSpace(cleanDesc)
+			}
+
 			var nameStr string
 			var descStr string
 
 			if i == m.selectedIndex {
 				nameStr = accentStyle.Render(sub.Name)
-				if sub.Description != "" {
-					descStr = descActiveStyle.Render(padding + sub.Description)
+				if cleanDesc != "" {
+					descStr = descActiveStyle.Render(padding + cleanDesc)
 				}
 				sb.WriteString(fmt.Sprintf("  ❯ %s%s\n", nameStr, descStr))
 			} else {
 				nameStr = dimStyle.Render(sub.Name)
-				if sub.Description != "" {
-					descStr = descDimStyle.Render(padding + sub.Description)
+				if cleanDesc != "" {
+					descStr = descDimStyle.Render(padding + cleanDesc)
 				}
 				sb.WriteString(fmt.Sprintf("    %s%s\n", nameStr, descStr))
 			}
@@ -375,7 +382,10 @@ func (m *commandModel) View() string {
 
 		// Active input description next to the name if available
 		if current.Description != "" {
-			sb.WriteString(descActiveStyle.Render("   " + current.Description))
+			desc := strings.ReplaceAll(current.Description, "\r", "")
+			desc = strings.ReplaceAll(desc, "\n", " ")
+			desc = strings.TrimSpace(desc)
+			sb.WriteString(descActiveStyle.Render("   " + desc))
 		}
 		sb.WriteString("\n")
 

--- a/internal/ilc/prompt.go
+++ b/internal/ilc/prompt.go
@@ -342,69 +342,48 @@ func (m *commandModel) View() string {
 			maxLen = max(maxLen, utf8.RuneCountInString(sub.Name))
 		}
 
-		totalSubs := len(subs)
-		pageSize := 5
-		if m.height > 30 {
-			pageSize = 8
-		}
-
-		startIdx := 0
-		endIdx := totalSubs
-		if totalSubs > pageSize {
-			startIdx = m.selectedIndex - pageSize/2
-			if startIdx < 0 {
-				startIdx = 0
-			}
-			endIdx = startIdx + pageSize
-			if endIdx > totalSubs {
-				endIdx = totalSubs
-				startIdx = endIdx - pageSize
-			}
-		}
-
-		if startIdx > 0 {
-			sb.WriteString(dimStyle.Render("  ▲  (more above)") + "\n")
-		}
-
-		for idx := startIdx; idx < endIdx; idx++ {
-			sub := subs[idx]
+		for i, sub := range subs {
 			padLen := maxLen - utf8.RuneCountInString(sub.Name)
 			if padLen < 0 {
 				padLen = 0
 			}
 			padding := strings.Repeat(" ", padLen+5)
 
-			var prefixAndName string
-			if idx == m.selectedIndex {
-				prefixAndName = fmt.Sprintf("  ❯ %s", accentStyle.Render(sub.Name))
-			} else {
-				prefixAndName = fmt.Sprintf("    %s", dimStyle.Render(sub.Name))
-			}
+			var nameStr string
+			var descStr string
 
-			if sub.Description != "" {
-				wrapWidth := m.width - (maxLen + 9)
-				if wrapWidth < 20 {
-					wrapWidth = 20
+			if i == m.selectedIndex {
+				nameStr = accentStyle.Render(sub.Name)
+				if sub.Description != "" {
+					wrapWidth := m.width - (maxLen + 9)
+					if wrapWidth < 20 {
+						wrapWidth = 20
+					}
+					desc := sub.Description
+					if utf8.RuneCountInString(desc) > wrapWidth {
+						desc = truncateText(desc, wrapWidth)
+					}
+					descStr = descActiveStyle.Render(padding + desc)
 				}
-				desc := sub.Description
-				if utf8.RuneCountInString(desc) > wrapWidth {
-					desc = truncateText(desc, wrapWidth)
-				}
-				var styledDesc string
-				if idx == m.selectedIndex {
-					styledDesc = descActiveStyle.Render(padding + desc)
-				} else {
-					styledDesc = descDimStyle.Render(padding + desc)
-				}
-				sb.WriteString(fmt.Sprintf("%s%s\n", prefixAndName, styledDesc))
+				sb.WriteString(fmt.Sprintf("  ❯ %s%s\n", nameStr, descStr))
 			} else {
-				sb.WriteString(prefixAndName + "\n")
+				nameStr = dimStyle.Render(sub.Name)
+				if sub.Description != "" {
+					wrapWidth := m.width - (maxLen + 9)
+					if wrapWidth < 20 {
+						wrapWidth = 20
+					}
+					desc := sub.Description
+					if utf8.RuneCountInString(desc) > wrapWidth {
+						desc = truncateText(desc, wrapWidth)
+					}
+					descStr = descDimStyle.Render(padding + desc)
+				}
+				sb.WriteString(fmt.Sprintf("    %s%s\n", nameStr, descStr))
 			}
 		}
 
-		if endIdx < totalSubs {
-			sb.WriteString(dimStyle.Render("  ▼  (more below)") + "\n")
-		}
+		sb.WriteString("\n" + helpStyle.Render("  [Enter] Select/Confirm  •  [Esc] Back  •  [Ctrl+C] Abort") + "\n")
 	} else {
 		// modeInputPrompt
 		// Render completed inputs in progressive/condensed form
@@ -448,14 +427,6 @@ func (m *commandModel) View() string {
 		}
 
 		// Help Guidelines (Hide confirm instruction if active input is invalid)
-		// Rendered statically at the end of View()
-	}
-
-	var helpText string
-	if m.mode == modeCommandSelect {
-		helpText = "  [Enter] Select/Confirm  •  [Esc] Back  •  [Ctrl+C] Abort"
-	} else {
-		current := m.missing[m.inputIndex]
 		var helpParts []string
 		if _, isAdjustable := current.Value.(inputs.AdjustableValue); isAdjustable {
 			helpParts = append(helpParts, "[Up/Down] +/-")
@@ -464,15 +435,8 @@ func (m *commandModel) View() string {
 			helpParts = append(helpParts, "[Enter] Confirm")
 		}
 		helpParts = append(helpParts, "[Esc] Back", "[Ctrl+C] Abort")
-		helpText = "  " + strings.Join(helpParts, "  •  ")
+		sb.WriteString("\n" + helpStyle.Render("  "+strings.Join(helpParts, "  •  ")) + "\n")
 	}
-
-	contentLines := strings.Count(sb.String(), "\n")
-	paddingNewlines := m.height - contentLines - 2
-	if paddingNewlines > 0 {
-		sb.WriteString(strings.Repeat("\n", paddingNewlines))
-	}
-	sb.WriteString(helpStyle.Render(helpText) + "\n")
 
 	return sb.String()
 }

--- a/internal/ilc/prompt.go
+++ b/internal/ilc/prompt.go
@@ -49,6 +49,7 @@ type commandModel struct {
 	optionsIndex int
 	inputErr     error
 	env          map[string]string
+	width        int
 }
 
 func (m *commandModel) currentSelection() Selection {
@@ -96,6 +97,11 @@ func (m *commandModel) Init() tea.Cmd {
 
 func (m *commandModel) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 	var cmd tea.Cmd
+
+	switch msg := msg.(type) {
+	case tea.WindowSizeMsg:
+		m.width = msg.Width
+	}
 
 	if m.mode == modeInputPrompt {
 		switch msg := msg.(type) {
@@ -341,21 +347,43 @@ func (m *commandModel) View() string {
 			}
 			padding := strings.Repeat(" ", padLen+5)
 
-			var nameStr string
-			var descStr string
-
+			var prefixAndName string
 			if i == m.selectedIndex {
-				nameStr = accentStyle.Render(sub.Name)
-				if sub.Description != "" {
-					descStr = descActiveStyle.Render(padding + sub.Description)
-				}
-				sb.WriteString(fmt.Sprintf("  ❯ %s%s\n", nameStr, descStr))
+				prefixAndName = fmt.Sprintf("  ❯ %s", accentStyle.Render(sub.Name))
 			} else {
-				nameStr = dimStyle.Render(sub.Name)
-				if sub.Description != "" {
-					descStr = descDimStyle.Render(padding + sub.Description)
+				prefixAndName = fmt.Sprintf("    %s", dimStyle.Render(sub.Name))
+			}
+
+			if sub.Description != "" {
+				wrapWidth := m.width - (maxLen + 9)
+				if wrapWidth < 20 {
+					wrapWidth = 20
 				}
-				sb.WriteString(fmt.Sprintf("    %s%s\n", nameStr, descStr))
+				lines := wrapText(sub.Description, wrapWidth)
+				if len(lines) > 0 {
+					var styledFirstLine string
+					if i == m.selectedIndex {
+						styledFirstLine = descActiveStyle.Render(padding + lines[0])
+					} else {
+						styledFirstLine = descDimStyle.Render(padding + lines[0])
+					}
+					sb.WriteString(fmt.Sprintf("%s%s\n", prefixAndName, styledFirstLine))
+
+					indent := strings.Repeat(" ", maxLen+9)
+					for _, line := range lines[1:] {
+						var styledLine string
+						if i == m.selectedIndex {
+							styledLine = descActiveStyle.Render(line)
+						} else {
+							styledLine = descDimStyle.Render(line)
+						}
+						sb.WriteString(fmt.Sprintf("%s%s\n", indent, styledLine))
+					}
+				} else {
+					sb.WriteString(prefixAndName + "\n")
+				}
+			} else {
+				sb.WriteString(prefixAndName + "\n")
 			}
 		}
 
@@ -448,6 +476,7 @@ func askCommands(sel Selection, env map[string]string) (Selection, error) {
 		selectedIndex: 0,
 		mode:          modeCommandSelect,
 		env:           env,
+		width:         80,
 	}
 
 	if sel.Runnable() {
@@ -494,6 +523,39 @@ func (m *commandModel) getBooleanOptions(current *inputs.Input) []inputs.InputOp
 		{Label: "true", Value: "true"},
 		{Label: "false", Value: "false"},
 	}
+}
+
+func wrapText(text string, limit int) []string {
+	if limit <= 0 {
+		return []string{text}
+	}
+	words := strings.Fields(text)
+	if len(words) == 0 {
+		return nil
+	}
+	var lines []string
+	var currentLine []string
+	currentLen := 0
+	for _, word := range words {
+		wordLen := utf8.RuneCountInString(word)
+		if currentLen + len(currentLine) + wordLen > limit {
+			if len(currentLine) > 0 {
+				lines = append(lines, strings.Join(currentLine, " "))
+				currentLine = nil
+				currentLen = 0
+			}
+			if wordLen > limit {
+				lines = append(lines, word)
+				continue
+			}
+		}
+		currentLine = append(currentLine, word)
+		currentLen += wordLen
+	}
+	if len(currentLine) > 0 {
+		lines = append(lines, strings.Join(currentLine, " "))
+	}
+	return lines
 }
 
 

--- a/internal/ilc/prompt.go
+++ b/internal/ilc/prompt.go
@@ -50,6 +50,7 @@ type commandModel struct {
 	inputErr     error
 	env          map[string]string
 	width        int
+	height       int
 }
 
 func (m *commandModel) currentSelection() Selection {
@@ -101,6 +102,7 @@ func (m *commandModel) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 	switch msg := msg.(type) {
 	case tea.WindowSizeMsg:
 		m.width = msg.Width
+		m.height = msg.Height
 	}
 
 	if m.mode == modeInputPrompt {
@@ -340,7 +342,32 @@ func (m *commandModel) View() string {
 			maxLen = max(maxLen, utf8.RuneCountInString(sub.Name))
 		}
 
-		for i, sub := range subs {
+		totalSubs := len(subs)
+		pageSize := 5
+		if m.height > 30 {
+			pageSize = 8
+		}
+
+		startIdx := 0
+		endIdx := totalSubs
+		if totalSubs > pageSize {
+			startIdx = m.selectedIndex - pageSize/2
+			if startIdx < 0 {
+				startIdx = 0
+			}
+			endIdx = startIdx + pageSize
+			if endIdx > totalSubs {
+				endIdx = totalSubs
+				startIdx = endIdx - pageSize
+			}
+		}
+
+		if startIdx > 0 {
+			sb.WriteString(dimStyle.Render("  ▲  (more above)") + "\n")
+		}
+
+		for idx := startIdx; idx < endIdx; idx++ {
+			sub := subs[idx]
 			padLen := maxLen - utf8.RuneCountInString(sub.Name)
 			if padLen < 0 {
 				padLen = 0
@@ -348,7 +375,7 @@ func (m *commandModel) View() string {
 			padding := strings.Repeat(" ", padLen+5)
 
 			var prefixAndName string
-			if i == m.selectedIndex {
+			if idx == m.selectedIndex {
 				prefixAndName = fmt.Sprintf("  ❯ %s", accentStyle.Render(sub.Name))
 			} else {
 				prefixAndName = fmt.Sprintf("    %s", dimStyle.Render(sub.Name))
@@ -362,7 +389,7 @@ func (m *commandModel) View() string {
 				lines := wrapText(sub.Description, wrapWidth)
 				if len(lines) > 0 {
 					var styledFirstLine string
-					if i == m.selectedIndex {
+					if idx == m.selectedIndex {
 						styledFirstLine = descActiveStyle.Render(padding + lines[0])
 					} else {
 						styledFirstLine = descDimStyle.Render(padding + lines[0])
@@ -372,7 +399,7 @@ func (m *commandModel) View() string {
 					indent := strings.Repeat(" ", maxLen+9)
 					for _, line := range lines[1:] {
 						var styledLine string
-						if i == m.selectedIndex {
+						if idx == m.selectedIndex {
 							styledLine = descActiveStyle.Render(line)
 						} else {
 							styledLine = descDimStyle.Render(line)
@@ -385,6 +412,10 @@ func (m *commandModel) View() string {
 			} else {
 				sb.WriteString(prefixAndName + "\n")
 			}
+		}
+
+		if endIdx < totalSubs {
+			sb.WriteString(dimStyle.Render("  ▼  (more below)") + "\n")
 		}
 
 		sb.WriteString("\n" + helpStyle.Render("  [Enter] Select/Confirm  •  [Esc] Back  •  [Ctrl+C] Abort") + "\n")
@@ -477,6 +508,7 @@ func askCommands(sel Selection, env map[string]string) (Selection, error) {
 		mode:          modeCommandSelect,
 		env:           env,
 		width:         80,
+		height:        24,
 	}
 
 	if sel.Runnable() {

--- a/internal/ilc/prompt.go
+++ b/internal/ilc/prompt.go
@@ -341,26 +341,19 @@ func (m *commandModel) View() string {
 			}
 			padding := strings.Repeat(" ", padLen+5)
 
-			var cleanDesc string
-			if sub.Description != "" {
-				cleanDesc = strings.ReplaceAll(sub.Description, "\r", "")
-				cleanDesc = strings.ReplaceAll(cleanDesc, "\n", " ")
-				cleanDesc = strings.TrimSpace(cleanDesc)
-			}
-
 			var nameStr string
 			var descStr string
 
 			if i == m.selectedIndex {
 				nameStr = accentStyle.Render(sub.Name)
-				if cleanDesc != "" {
-					descStr = descActiveStyle.Render(padding + cleanDesc)
+				if sub.Description != "" {
+					descStr = descActiveStyle.Render(padding + sub.Description)
 				}
 				sb.WriteString(fmt.Sprintf("  ❯ %s%s\n", nameStr, descStr))
 			} else {
 				nameStr = dimStyle.Render(sub.Name)
-				if cleanDesc != "" {
-					descStr = descDimStyle.Render(padding + cleanDesc)
+				if sub.Description != "" {
+					descStr = descDimStyle.Render(padding + sub.Description)
 				}
 				sb.WriteString(fmt.Sprintf("    %s%s\n", nameStr, descStr))
 			}
@@ -382,10 +375,7 @@ func (m *commandModel) View() string {
 
 		// Active input description next to the name if available
 		if current.Description != "" {
-			desc := strings.ReplaceAll(current.Description, "\r", "")
-			desc = strings.ReplaceAll(desc, "\n", " ")
-			desc = strings.TrimSpace(desc)
-			sb.WriteString(descActiveStyle.Render("   " + desc))
+			sb.WriteString(descActiveStyle.Render("   " + current.Description))
 		}
 		sb.WriteString("\n")
 

--- a/internal/ilc/prompt.go
+++ b/internal/ilc/prompt.go
@@ -386,29 +386,17 @@ func (m *commandModel) View() string {
 				if wrapWidth < 20 {
 					wrapWidth = 20
 				}
-				lines := wrapText(sub.Description, wrapWidth)
-				if len(lines) > 0 {
-					var styledFirstLine string
-					if idx == m.selectedIndex {
-						styledFirstLine = descActiveStyle.Render(padding + lines[0])
-					} else {
-						styledFirstLine = descDimStyle.Render(padding + lines[0])
-					}
-					sb.WriteString(fmt.Sprintf("%s%s\n", prefixAndName, styledFirstLine))
-
-					indent := strings.Repeat(" ", maxLen+9)
-					for _, line := range lines[1:] {
-						var styledLine string
-						if idx == m.selectedIndex {
-							styledLine = descActiveStyle.Render(line)
-						} else {
-							styledLine = descDimStyle.Render(line)
-						}
-						sb.WriteString(fmt.Sprintf("%s%s\n", indent, styledLine))
-					}
-				} else {
-					sb.WriteString(prefixAndName + "\n")
+				desc := sub.Description
+				if utf8.RuneCountInString(desc) > wrapWidth {
+					desc = truncateText(desc, wrapWidth)
 				}
+				var styledDesc string
+				if idx == m.selectedIndex {
+					styledDesc = descActiveStyle.Render(padding + desc)
+				} else {
+					styledDesc = descDimStyle.Render(padding + desc)
+				}
+				sb.WriteString(fmt.Sprintf("%s%s\n", prefixAndName, styledDesc))
 			} else {
 				sb.WriteString(prefixAndName + "\n")
 			}
@@ -417,8 +405,6 @@ func (m *commandModel) View() string {
 		if endIdx < totalSubs {
 			sb.WriteString(dimStyle.Render("  ▼  (more below)") + "\n")
 		}
-
-		sb.WriteString("\n" + helpStyle.Render("  [Enter] Select/Confirm  •  [Esc] Back  •  [Ctrl+C] Abort") + "\n")
 	} else {
 		// modeInputPrompt
 		// Render completed inputs in progressive/condensed form
@@ -462,6 +448,14 @@ func (m *commandModel) View() string {
 		}
 
 		// Help Guidelines (Hide confirm instruction if active input is invalid)
+		// Rendered statically at the end of View()
+	}
+
+	var helpText string
+	if m.mode == modeCommandSelect {
+		helpText = "  [Enter] Select/Confirm  •  [Esc] Back  •  [Ctrl+C] Abort"
+	} else {
+		current := m.missing[m.inputIndex]
 		var helpParts []string
 		if _, isAdjustable := current.Value.(inputs.AdjustableValue); isAdjustable {
 			helpParts = append(helpParts, "[Up/Down] +/-")
@@ -470,8 +464,15 @@ func (m *commandModel) View() string {
 			helpParts = append(helpParts, "[Enter] Confirm")
 		}
 		helpParts = append(helpParts, "[Esc] Back", "[Ctrl+C] Abort")
-		sb.WriteString("\n" + helpStyle.Render("  "+strings.Join(helpParts, "  •  ")) + "\n")
+		helpText = "  " + strings.Join(helpParts, "  •  ")
 	}
+
+	contentLines := strings.Count(sb.String(), "\n")
+	paddingNewlines := m.height - contentLines - 2
+	if paddingNewlines > 0 {
+		sb.WriteString(strings.Repeat("\n", paddingNewlines))
+	}
+	sb.WriteString(helpStyle.Render(helpText) + "\n")
 
 	return sb.String()
 }
@@ -557,37 +558,18 @@ func (m *commandModel) getBooleanOptions(current *inputs.Input) []inputs.InputOp
 	}
 }
 
-func wrapText(text string, limit int) []string {
-	if limit <= 0 {
-		return []string{text}
-	}
-	words := strings.Fields(text)
-	if len(words) == 0 {
-		return nil
-	}
-	var lines []string
-	var currentLine []string
-	currentLen := 0
-	for _, word := range words {
-		wordLen := utf8.RuneCountInString(word)
-		if currentLen + len(currentLine) + wordLen > limit {
-			if len(currentLine) > 0 {
-				lines = append(lines, strings.Join(currentLine, " "))
-				currentLine = nil
-				currentLen = 0
-			}
-			if wordLen > limit {
-				lines = append(lines, word)
-				continue
-			}
+func truncateText(text string, limit int) string {
+	if limit <= 3 {
+		if utf8.RuneCountInString(text) <= limit {
+			return text
 		}
-		currentLine = append(currentLine, word)
-		currentLen += wordLen
+		return "..."
 	}
-	if len(currentLine) > 0 {
-		lines = append(lines, strings.Join(currentLine, " "))
+	if utf8.RuneCountInString(text) <= limit {
+		return text
 	}
-	return lines
+	runes := []rune(text)
+	return string(runes[:limit-3]) + "..."
 }
 
 

--- a/internal/ilc/prompt_test.go
+++ b/internal/ilc/prompt_test.go
@@ -449,6 +449,45 @@ func TestCommandModel_CommandSelectMode_Wrapping(t *testing.T) {
 	assert.Contains(t, viewStr, "\n             feature of macOS.")
 }
 
+func TestCommandModel_CommandSelectMode_Pagination(t *testing.T) {
+	rootCmd := Command{
+		Name:        "root",
+		Description: "root command",
+		Commands: SubCommands{
+			{Command: Command{Name: "sub1", Description: "sub1 desc"}},
+			{Command: Command{Name: "sub2", Description: "sub2 desc"}},
+			{Command: Command{Name: "sub3", Description: "sub3 desc"}},
+			{Command: Command{Name: "sub4", Description: "sub4 desc"}},
+			{Command: Command{Name: "sub5", Description: "sub5 desc"}},
+			{Command: Command{Name: "sub6", Description: "sub6 desc"}},
+			{Command: Command{Name: "sub7", Description: "sub7 desc"}},
+		},
+	}
+	history := []Selection{
+		{
+			commands: []Command{rootCmd},
+		},
+	}
+	m := &commandModel{
+		title:         "Choose command",
+		mode:          modeCommandSelect,
+		history:       history,
+		selectedIndex: 5,
+		width:         80,
+		height:        24,
+	}
+
+	viewStr := m.View()
+	// Should contain scroll up indicator
+	assert.Contains(t, viewStr, "▲  (more above)")
+	// Should contain visible items
+	assert.Contains(t, viewStr, "sub6")
+	assert.Contains(t, viewStr, "sub7")
+	// Should NOT contain hidden items
+	assert.NotContains(t, viewStr, "sub1")
+	assert.NotContains(t, viewStr, "sub2")
+}
+
 
 
 

--- a/internal/ilc/prompt_test.go
+++ b/internal/ilc/prompt_test.go
@@ -451,44 +451,6 @@ func TestCommandModel_CommandSelectMode_Truncation(t *testing.T) {
 	assert.Contains(t, viewStr, "The Dock is a prominent ...")
 }
 
-func TestCommandModel_CommandSelectMode_Pagination(t *testing.T) {
-	rootCmd := Command{
-		Name:        "root",
-		Description: "root command",
-		Commands: SubCommands{
-			{Command: Command{Name: "sub1", Description: "sub1 desc"}},
-			{Command: Command{Name: "sub2", Description: "sub2 desc"}},
-			{Command: Command{Name: "sub3", Description: "sub3 desc"}},
-			{Command: Command{Name: "sub4", Description: "sub4 desc"}},
-			{Command: Command{Name: "sub5", Description: "sub5 desc"}},
-			{Command: Command{Name: "sub6", Description: "sub6 desc"}},
-			{Command: Command{Name: "sub7", Description: "sub7 desc"}},
-		},
-	}
-	history := []Selection{
-		{
-			commands: []Command{rootCmd},
-		},
-	}
-	m := &commandModel{
-		title:         "Choose command",
-		mode:          modeCommandSelect,
-		history:       history,
-		selectedIndex: 5,
-		width:         80,
-		height:        24,
-	}
-
-	viewStr := m.View()
-	// Should contain scroll up indicator
-	assert.Contains(t, viewStr, "▲  (more above)")
-	// Should contain visible items
-	assert.Contains(t, viewStr, "sub6")
-	assert.Contains(t, viewStr, "sub7")
-	// Should NOT contain hidden items
-	assert.NotContains(t, viewStr, "sub1")
-	assert.NotContains(t, viewStr, "sub2")
-}
 
 
 

--- a/internal/ilc/prompt_test.go
+++ b/internal/ilc/prompt_test.go
@@ -419,7 +419,7 @@ func TestCommandModel_SelectableBooleanInput(t *testing.T) {
 	assert.Equal(t, "Yes Please", opts[0].Label)
 }
 
-func TestCommandModel_CommandSelectMode_Wrapping(t *testing.T) {
+func TestCommandModel_CommandSelectMode_Truncation(t *testing.T) {
 	rootCmd := Command{
 		Name:        "root",
 		Description: "root command",
@@ -440,13 +440,15 @@ func TestCommandModel_CommandSelectMode_Wrapping(t *testing.T) {
 		mode:          modeCommandSelect,
 		history:       history,
 		selectedIndex: 0,
-		width:         40, // narrow width to force wrapping
+		width:         40, // narrow width to force truncation
 	}
 
 	viewStr := m.View()
 	// dock name length is 4. maxLen is 4. maxLen + 9 is 13.
-	// Subsequent lines should be indented by 13 spaces.
-	assert.Contains(t, viewStr, "\n             feature of macOS.")
+	// wrapWidth is 40 - 13 = 27.
+	// The truncated description should be 27 runes total including ellipsis.
+	// "The Dock is a prominent ..." (27 runes)
+	assert.Contains(t, viewStr, "The Dock is a prominent ...")
 }
 
 func TestCommandModel_CommandSelectMode_Pagination(t *testing.T) {

--- a/internal/ilc/prompt_test.go
+++ b/internal/ilc/prompt_test.go
@@ -419,6 +419,36 @@ func TestCommandModel_SelectableBooleanInput(t *testing.T) {
 	assert.Equal(t, "Yes Please", opts[0].Label)
 }
 
+func TestCommandModel_CommandSelectMode_Wrapping(t *testing.T) {
+	rootCmd := Command{
+		Name:        "root",
+		Description: "root command",
+		Commands: SubCommands{
+			{Command: Command{
+				Name:        "dock",
+				Description: "The Dock is a prominent feature of macOS. It is used to launch applications.",
+			}},
+		},
+	}
+	history := []Selection{
+		{
+			commands: []Command{rootCmd},
+		},
+	}
+	m := &commandModel{
+		title:         "Choose command",
+		mode:          modeCommandSelect,
+		history:       history,
+		selectedIndex: 0,
+		width:         40, // narrow width to force wrapping
+	}
+
+	viewStr := m.View()
+	// dock name length is 4. maxLen is 4. maxLen + 9 is 13.
+	// Subsequent lines should be indented by 13 spaces.
+	assert.Contains(t, viewStr, "\n             feature of macOS.")
+}
+
 
 
 

--- a/internal/ilc/yaml.go
+++ b/internal/ilc/yaml.go
@@ -3,6 +3,7 @@ package ilc
 import (
 	"fmt"
 	"regexp"
+	"strings"
 
 	"github.com/evilmarty/ilc/internal/inputs"
 	orderedmap "github.com/wk8/go-ordered-map/v2"
@@ -43,6 +44,7 @@ func (x *yamlSubCommand) UnmarshalYAML(node *yaml.Node) error {
 	} else if err := node.Decode(&subcommand); err != nil {
 		return err
 	}
+	subcommand.Description = strings.TrimSpace(subcommand.Description)
 	*x = yamlSubCommand(subcommand)
 	return nil
 }
@@ -194,7 +196,7 @@ func (x *yamlInput) UnmarshalYAML(node *yaml.Node) error {
 		}
 	}
 
-	x.Description = temp.Description
+	x.Description = strings.TrimSpace(temp.Description)
 	x.Options = temp.Options
 	x.Value = val
 	return nil

--- a/internal/inputs/tui.go
+++ b/internal/inputs/tui.go
@@ -151,11 +151,6 @@ func (m *tuiModel) View() string {
 	// Progress and Label
 	progress := fmt.Sprintf("[%d/%d]", m.currentIndex+1, len(m.inputs))
 	prompt := current.Description
-	if prompt != "" {
-		prompt = strings.ReplaceAll(prompt, "\r", "")
-		prompt = strings.ReplaceAll(prompt, "\n", " ")
-		prompt = strings.TrimSpace(prompt)
-	}
 	if prompt == "" {
 		if current.Selectable() || m.isBooleanInput(current) {
 			prompt = fmt.Sprintf("Choose a %s", current.Name)

--- a/internal/inputs/tui.go
+++ b/internal/inputs/tui.go
@@ -151,6 +151,11 @@ func (m *tuiModel) View() string {
 	// Progress and Label
 	progress := fmt.Sprintf("[%d/%d]", m.currentIndex+1, len(m.inputs))
 	prompt := current.Description
+	if prompt != "" {
+		prompt = strings.ReplaceAll(prompt, "\r", "")
+		prompt = strings.ReplaceAll(prompt, "\n", " ")
+		prompt = strings.TrimSpace(prompt)
+	}
 	if prompt == "" {
 		if current.Selectable() || m.isBooleanInput(current) {
 			prompt = fmt.Sprintf("Choose a %s", current.Name)


### PR DESCRIPTION
This pull request improves how command descriptions are handled and displayed in the CLI tool, focusing on trimming whitespace from YAML descriptions and enhancing the UI to better handle and display long descriptions. The most important changes are grouped below:

**YAML Parsing and Description Handling:**

* All command, subcommand, and input descriptions loaded from YAML are now trimmed of leading and trailing whitespace, ensuring cleaner and more predictable display. (`internal/ilc/config.go`, `internal/ilc/yaml.go`) [[1]](diffhunk://#diff-9495882791ad48094b3bd3fab07f24078fd6c6aa5bdd8ce78d2559369934b06bR5-R22) [[2]](diffhunk://#diff-7569eb9f4eb11e91afd67028886b6dc3aa57cd1c148d97cb8b49f85a49b25432R47) [[3]](diffhunk://#diff-7569eb9f4eb11e91afd67028886b6dc3aa57cd1c148d97cb8b49f85a49b25432L197-R199)
* Added a test to verify that descriptions with newlines and extra whitespace are correctly trimmed when loading configuration files. (`internal/ilc/config_test.go`)

**UI and Terminal Rendering Improvements:**

* The command selection UI now dynamically tracks terminal width and height, adjusting the display accordingly. (`internal/ilc/prompt.go`) [[1]](diffhunk://#diff-345d23de86d87c7fd65db403bbc2e45eae7e3a477ba879a4610fa42d7765b209R52-R53) [[2]](diffhunk://#diff-345d23de86d87c7fd65db403bbc2e45eae7e3a477ba879a4610fa42d7765b209R102-R107) [[3]](diffhunk://#diff-345d23de86d87c7fd65db403bbc2e45eae7e3a477ba879a4610fa42d7765b209R475-R476)
* Long descriptions in the command selection view are truncated with an ellipsis based on available width, preventing UI overflow and improving readability. (`internal/ilc/prompt.go`) [[1]](diffhunk://#diff-345d23de86d87c7fd65db403bbc2e45eae7e3a477ba879a4610fa42d7765b209L350-R380) [[2]](diffhunk://#diff-345d23de86d87c7fd65db403bbc2e45eae7e3a477ba879a4610fa42d7765b209R525-R538)
* Added a test to confirm that description truncation works as expected when the terminal width is narrow. (`internal/ilc/prompt_test.go`)

**Other UI Tweaks:**

* Simplified the rendering of the command title in the UI for a cleaner look. (`internal/ilc/prompt.go`)